### PR TITLE
add favicon links for web browser compatibility

### DIFF
--- a/breaking-benjabad.html
+++ b/breaking-benjabad.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sigma Site</title>
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="stylesheet" href="/styles/style.css">
 </head>
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sigma Site</title>
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="stylesheet" href="/styles/style.css">
 </head>
 


### PR DESCRIPTION
turns out some web browsers dont just grab `favicon.ico` from the root of a website automatically. adding this tag in will make them grab it anyway